### PR TITLE
Initial commit of linear losses.

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ target/
 
 # vscode
 .vscode/
+
+# .bat
+build.bat
+build.txt
+tests/Leap_Second.dat
+tests/deltat.data
+tests/deltat.preds

--- a/pywr_dcopf/_glpk_dcopf_solver.pyx
+++ b/pywr_dcopf/_glpk_dcopf_solver.pyx
@@ -152,7 +152,7 @@ cdef class CythonGLPKDCOPFSolver:
                     cols[self.idx_col_phase + other_ibus] += susceptance
                     # Add loss to bus power balance
                     cols[self.idx_col_line_losses + iloss] += -1.0
-                    print(ibus, bus, some_node, iloss)
+                    # print(ibus, bus, some_node, iloss)
                     # Create a constraint for loss coming into bus from other_bus
                     ind = <int*>malloc(4 * sizeof(int))
                     val = <double*>malloc(4 * sizeof(double))

--- a/pywr_dcopf/_glpk_dcopf_solver.pyx
+++ b/pywr_dcopf/_glpk_dcopf_solver.pyx
@@ -23,8 +23,10 @@ cdef class CythonGLPKDCOPFSolver:
     cdef int idx_col_generation
     cdef int idx_col_load
     cdef int idx_col_phase
+    cdef int idx_col_line_losses
     cdef int idx_row_power_flow
     cdef int idx_row_line_capacity
+    cdef int idx_row_line_losses
     cdef int idx_row_batteries
 
     cdef public list buses
@@ -106,7 +108,6 @@ cdef class CythonGLPKDCOPFSolver:
                 for load in some_node.outputs:
                     loads.append(load)
 
-
         # clear the previous problem
         glp_erase_prob(self.prob)
         glp_set_obj_dir(self.prob, GLP_MIN)
@@ -114,6 +115,8 @@ cdef class CythonGLPKDCOPFSolver:
         self.idx_col_generation = glp_add_cols(self.prob, <int>(len(generators)))
         self.idx_col_load = glp_add_cols(self.prob, <int>(len(loads)))
         self.idx_col_phase = glp_add_cols(self.prob, <int>(len(buses)))
+        # Two loss columns (+/-) for each line
+        self.idx_col_line_losses = glp_add_cols(self.prob, <int>(2*len(lines)))
 
         # explicitly set bounds on route and demand columns
         for col, route in enumerate(generators):
@@ -123,9 +126,13 @@ cdef class CythonGLPKDCOPFSolver:
         for col, route in enumerate(buses):
             # TODO what should the bounds constraints on the buses be??
             set_col_bnds(self.prob, self.idx_col_phase+col, GLP_LO, 0.0, DBL_MAX)
+        for col in range(2*len(lines)):
+            set_col_bnds(self.prob, self.idx_col_line_losses+col, GLP_LO, 0.0, DBL_MAX)
 
         # Power flow constraints
         self.idx_row_power_flow = glp_add_rows(self.prob, len(buses))
+        self.idx_row_line_losses = glp_add_rows(self.prob, 2*len(lines))
+        iloss = 0
         for ibus, bus in enumerate(buses):
             cols = defaultdict(lambda: 0.0)
 
@@ -143,6 +150,26 @@ cdef class CythonGLPKDCOPFSolver:
 
                     cols[self.idx_col_phase + ibus] += -susceptance
                     cols[self.idx_col_phase + other_ibus] += susceptance
+                    # Add loss to bus power balance
+                    cols[self.idx_col_line_losses + iloss] += -1.0
+                    print(ibus, bus, some_node, iloss)
+                    # Create a constraint for loss coming into bus from other_bus
+                    ind = <int*>malloc(4 * sizeof(int))
+                    val = <double*>malloc(4 * sizeof(double))
+                    # Loss > line flow
+                    ind[1] = self.idx_col_line_losses + iloss
+                    val[1] = -1.0
+                    ind[2] = self.idx_col_phase + ibus
+                    val[2] = -susceptance * some_node.loss
+                    ind[3] = self.idx_col_phase + other_ibus
+                    val[3] = susceptance * some_node.loss
+
+                    set_mat_row(self.prob, self.idx_row_line_losses+iloss, 3, ind, val)
+                    set_row_bnds(self.prob, self.idx_row_line_losses+iloss, GLP_UP, 0.0, 0.0)
+                    free(ind)
+                    free(val)
+                    iloss += 1
+
                 elif isinstance(some_node, Generator):
                     igen = generators.index(some_node)
                     cols[self.idx_col_generation+igen] += 1.0
@@ -457,8 +484,6 @@ cdef class CythonGLPKDCOPFSolver:
         for row, line in enumerate(lines):
             l = glp_get_row_prim(self.prob, self.idx_row_line_capacity+row)
             line.commit(scenario_index.global_id, l)
-
-
 
     cpdef dump_mps(self, filename):
         glp_write_mps(self.prob, GLP_MPS_FILE, NULL, filename)

--- a/pywr_dcopf/core.py
+++ b/pywr_dcopf/core.py
@@ -132,6 +132,7 @@ class Line(with_metaclass(NodeMeta, Drawable, Connectable, BaseNode)):
 
     def __init__(self, *args, **kwargs):
         self.reactance = kwargs.pop('reactance', 0.1)
+        self.loss = kwargs.pop('loss', 0.0)
         super().__init__(*args, **kwargs)
 
 

--- a/tests/models/basic-losses.json
+++ b/tests/models/basic-losses.json
@@ -1,0 +1,52 @@
+{
+  "metadata": {
+    "title": "Simple triangular network.",
+    "minimum_version": "1.0"
+  },
+  "timestepper": {
+    "start": "2019-01-01",
+    "end": "2019-01-02",
+    "timestep": "H"
+  },
+  "nodes": [
+    {
+      "name": "gen1",
+      "type": "generator",
+      "max_flow": 50,
+      "cost": 1
+    },
+    {
+      "name": "gen2",
+      "type": "generator",
+      "max_flow": 100,
+      "cost": 2
+    },
+    {
+      "name": "load1",
+      "type": "load",
+      "max_flow": 150,
+      "cost": -10
+    },
+    {
+      "name": "bus1",
+      "type": "bus"
+    },
+    {
+      "name": "bus2",
+      "type": "bus"
+    },
+    {
+      "name": "line12",
+      "type": "line",
+      "reactance": 0.1,
+      "loss": 0.15
+    }
+  ],
+  "edges": [
+    ["gen1", "bus1"],
+    ["gen2", "bus2"],
+    ["bus1", "load1"],
+    ["bus1", "line12"],
+    ["line12", "bus2"]
+  ]
+}

--- a/tests/models/simple-losses.json
+++ b/tests/models/simple-losses.json
@@ -1,0 +1,72 @@
+{
+  "metadata": {
+    "title": "Simple triangular network.",
+    "minimum_version": "1.0"
+  },
+  "timestepper": {
+    "start": "2019-01-01",
+    "end": "2019-02-01",
+    "timestep": "H"
+  },
+  "nodes": [
+    {
+      "name": "gen1",
+      "type": "generator",
+      "max_flow": 100,
+      "cost": 1
+    },
+    {
+      "name": "gen2",
+      "type": "generator",
+      "max_flow": 100,
+      "cost": 2
+    },
+    {
+      "name": "load3",
+      "type": "load",
+      "max_flow": 150,
+      "cost": -10
+    },
+    {
+      "name": "bus1",
+      "type": "bus"
+    },
+    {
+      "name": "bus2",
+      "type": "bus"
+    },
+    {
+      "name": "bus3",
+      "type": "bus"
+    },
+    {
+      "name": "line12",
+      "type": "line",
+      "reactance": 0.1,
+      "loss": 0.1
+    },
+    {
+      "name": "line13",
+      "type": "line",
+      "reactance": 0.1,
+      "loss": 0.1
+    },
+    {
+      "name": "line23",
+      "type": "line",
+      "reactance": 0.1,
+      "loss": 0.1
+    }
+  ],
+  "edges": [
+    ["gen1", "bus1"],
+    ["gen2", "bus2"],
+    ["load3", "bus3"],
+    ["bus1", "line12"],
+    ["line12", "bus2"],
+    ["bus1", "line13"],
+    ["line13", "bus3"],
+    ["bus2", "line23"],
+    ["line23", "bus3"]
+  ]
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -155,6 +155,16 @@ def test_simple_losses():
     np.testing.assert_allclose(m.nodes['line13'].flow, [100.0 - 100/9])
     np.testing.assert_allclose(m.nodes['line23'].flow, [gen2 + 100/9 - line12_losses])
 
+def test_basic_losses():
+
+    m = Model.load(os.path.join(TEST_FOLDER,'models','basic-losses.json'), solver='glpk-dcopf')
+
+    m.setup()
+    m.run()
+
+    np.testing.assert_allclose(m.nodes['gen1'].flow,[50])
+    np.testing.assert_allclose(m.nodes['gen2'].flow,[100])
+    np.testing.assert_allclose(m.nodes['load1'].flow,[15])
 
 def test_simple_pv():
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -132,6 +132,30 @@ def test_simple_piecewise_generator():
     np.testing.assert_allclose(m.nodes['line23'].flow, [100.0 - 50/3])
 
 
+def test_simple_losses():
+
+    m = Model.load(os.path.join(TEST_FOLDER, 'models', 'simple-losses.json'), solver='glpk-dcopf')
+
+    m.setup()
+    m.run()
+
+    # Gen1 losses
+    line12_losses = 0.1 * 100/9
+    line13_losses = 0.1 * (100 - 100/9)
+    line23_losses = 0.1 * (100/9 - line12_losses)
+    gen1_losses = line12_losses + line13_losses + line23_losses
+
+    gen2 = (150 - 100 + gen1_losses) / (1 - 0.1)
+
+    np.testing.assert_allclose(m.nodes['gen1'].flow, [100.0])
+    np.testing.assert_allclose(m.nodes['gen2'].flow, [gen2])
+    np.testing.assert_allclose(m.nodes['load3'].flow, [150.0])
+
+    np.testing.assert_allclose(m.nodes['line12'].flow, [100/9])
+    np.testing.assert_allclose(m.nodes['line13'].flow, [100.0 - 100/9])
+    np.testing.assert_allclose(m.nodes['line23'].flow, [gen2 + 100/9 - line12_losses])
+
+
 def test_simple_pv():
 
     m = Model.load(os.path.join(TEST_FOLDER, 'models', 'simple-pv.json'), solver='glpk-dcopf')


### PR DESCRIPTION
This is initial support for linear losses on the line nodes. It by default now adds two additional columns and two additional rows for each line. This could be made optional by only adding those columns & rows for lines that have a loss defined. Loss defaults to zero.

The columns represent the loss in each direction of each line. The rows are such that only one of these should be active (> 0) at any given time. I.e. the if the power flow is coming into the bus then the loss is non-zero, if it is leaving the bus (i.e. -ve) the loss is zero.

I've added a basic test that I think gives the correct results. The "flow" attribute on a line is the power flow prior to any losses. The losses themselves are currently not saved or returned from the solver.


